### PR TITLE
w02_프린터 큐 - 혜선

### DIFF
--- a/src/main/java/org/example/yhs3237/w02_printerQueue/baekjoon1966.java
+++ b/src/main/java/org/example/yhs3237/w02_printerQueue/baekjoon1966.java
@@ -1,0 +1,56 @@
+package org.example.yhs3237.w02_printerQueue;
+
+import java.io.*;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class baekjoon1966 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringBuilder sb = new StringBuilder();
+
+        int testCase = Integer.parseInt(br.readLine());
+
+        for (int t = 1; t <= testCase; t++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            int N = Integer.parseInt(st.nextToken()); // 문서의 개수
+            int M = Integer.parseInt(st.nextToken()); // 인쇄 순서가 궁금한 문서
+
+
+            Queue<int[]> queue = new LinkedList<>(); // 문서의 중요도와 위치 저장
+            PriorityQueue<Integer> priorityQueue = new PriorityQueue<>(Collections.reverseOrder()); // 최대 힙 (중요도 정보 저장)
+
+            // 큐에 문서 정보(중요도, 위치 / 중요도) 저장
+            st = new StringTokenizer(br.readLine());
+            for (int i = 0; i < N; i++) {
+                int priority = Integer.parseInt(st.nextToken()); // 문서의 중요도 (입력받음)
+                queue.add(new int[] {priority, i}); // 큐에 추가
+                priorityQueue.add(priority); // 우선순위 큐에도 추가
+            }
+
+            int turn = 0; // 실행 순서
+
+            while (!queue.isEmpty()) {
+                int[] out = queue.poll(); // 큐에서 문서 꺼내기
+
+                if (out[0] < priorityQueue.peek()) { // 최댓값이 아니라면 다시 큐에 추가
+                    queue.add(out);
+                } else {
+                    turn++; // 실행됨
+                    priorityQueue.poll(); // 우선순위 큐에서도 제거
+
+                    if (out[1] == M) { // 목표 문서 프린트 완료
+                        break;
+                    }
+                }
+            }
+            sb.append(turn).append("\n");
+        }
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## #️⃣ 문제링크
https://www.acmicpc.net/problem/1966
<!-- url  첨부 -->

## 📝 풀이 내용
한달 전쯤에 이 문제를 풀다가 같은 중요도를 갖는 문서를 처리하지 못해서 막혔었는데, 강사님이 우선순위 큐를 써야한다고 조언해주셨었습니다.
근데 우선순위 큐를 몰라서 풀지 않았습니다..ㅎ
이번에는 조언대로 우선순위 큐와 큐를 활용해 풀었습니다.

0️⃣첫 시도
- 우선순위 큐만 사용 -> 우선순위 큐는 동일한 우선순위의 값들을 무작위로 처리하기 때문에 문서의 정확한 프린터 순서를 보장할 수 없음
- 큐만 사용 -> 문서의 중요도가 가장 높은 문서가 출력이 될 때마다 중요도가 가장 높은 문서를 갱신해줘야 해서 시간 초과 문제 발생(잦은 반복)

1️⃣문서에 대한 2가지 정보를 어떻게 처리할 것인가?
- 지난 문제 풀이(탑)에서는 클래스를 사용했었는데, 이번에는 배열을 사용해보았습니다.
- 큐의 각 요소를 문서에 대한 정보를 담는 배열로 하여, [0] = 문서의 중요도 정보 / [1] = 문서의 위치 정보를 저장하였습니다.

2️⃣ 같은 중요도의 문서를 어떻게 처리할 것인가?
- 우선 순위 큐(최대 힙을 구현)에는 문서의 중요도만을 저장하여 중요도가 가장 높은 문서가 부모 노드에 오도록 하였습니다.
- 그리고 일반 큐에서 꺼낸 문서의 중요도와 비교하며 중요도가 낮으면 뒤로 보내는 과정을 통해 같은 중요도의 문서더라도 위치에 따라 프린터 되도록 하였습니다.

3️⃣ 중요도가 가장 높은 문서를 갱신하는 문제를 어떻게 해결할 것인가?
- 큐에서 문서를 꺼내서 중요도가 가장 높은 문서보다 중요도가 낮으면 다시 큐에 추가하고, 중요도가 가장 높은 문서가 나오면 프린트하고 우선 순위 큐에서도 제거합니다. 
- 우선 순위 큐에서 제거하면 알아서 중요도가 가장 높은 문서가 갱신됩니다.
<!-- 접근 방식 및 코드 설명 (코드에 주석으로 자세히 달아놓아도 좋습니다!) -->

#### 제출 이력
![스크린샷 2025-02-19 154604](https://github.com/user-attachments/assets/fa45c41a-96d6-4ffc-bc71-0909f0322cbf)

<!-- 캡쳐한 이미지 -->


### 💬 리뷰 요구사항 (선택)
> 저는 우선순위 큐와 큐를 모두 사용했는데, 둘 중 하나만 사용하여 처리하는 방법이 있을까요?

<!--  리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 ex) 이 부분을 더 최적화하고 싶은데 좋은 방법이 있을까요? -->
