### PR TITLE
w02_프린터큐 - 이루

### DIFF
--- a/src/main/java/org/example/iroo2001/w02_프린터큐/Main.java
+++ b/src/main/java/org/example/iroo2001/w02_프린터큐/Main.java
@@ -1,0 +1,59 @@
+package org.example.iroo2001.w02_프린터큐;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int[] priority;
+	static ArrayDeque<Integer> q;
+
+	static int printer() {
+		int doc;
+
+		while (!q.isEmpty()) {
+			doc = q.poll();
+			for (int i = 9; i > doc % 10; i--) {
+				if (priority[i] > 0) {
+					q.offer(doc);
+					doc = 0;
+					break;
+				}
+			}
+			if (doc > 10) {
+				return q.size();
+			}
+			priority[doc % 10]--;
+		}
+		return 0;
+	}
+
+	public static void main(String[] args) throws IOException {
+		int t, n, m, doc;
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+
+		st = new StringTokenizer(br.readLine());
+		t = Integer.parseInt(st.nextToken());
+		for (int tc = 0; tc < t; tc++) {
+			st = new StringTokenizer(br.readLine());
+			n = Integer.parseInt(st.nextToken());
+			m = Integer.parseInt(st.nextToken());
+
+			priority = new int[10];
+			q = new ArrayDeque<>();
+			st = new StringTokenizer(br.readLine());
+			for (int i = 0; i < n; i++) {
+				doc = Integer.parseInt(st.nextToken()) + ((i == m) ? 10 : 0);
+				priority[doc % 10]++;
+				q.offer(doc);
+			}
+			System.out.println(n - printer());
+		}
+
+		br.close();
+	}
+}


### PR DESCRIPTION
## #️⃣ 문제링크
[백준 1966 - 프린터 큐](https://www.acmicpc.net/problem/1966)

## 📝 풀이 내용
- 사용한 구조
- int[] priority : 1~9까지의 중요도별로, 각 중요도의 문서가 현재 큐에 몇개 있는지 저장 (카운팅 배열)
- ArrayDeque<> q : 각 문서를 순서대로 저장하는 큐
- 목표하는 문서 마킹 : 중요도는 1~9이므로, 목표하는 문서는 10을 더하여 표시함
-> 중요도 = 문서%10

1. 모든 문서를 q에 넣으며, 각 문서의 중요도를 카운팅
2. m번째 문서의 경우, 중요도+10을 q에 넣음
3. 큐의 값을 앞에서부터 하나씩 뽑으며, 더 높은 중요도가 저장되어있는지 priority 배열로 확인
4. 더 높은 중요도의 문서가 있는 경우, 현재 문서를 다시 큐의 마지막에 넣음
5. 더 높은 중요도가 없는 경우, 만약 현재 문서>10이면 목표한 문서이므로 return
6. 더 높은 중요도가 없는데 현재문서<=10이면 출력 & priority 카운팅 배열에서 1 빼기

- return 값은 남은 큐의 크기 == 출력되지 않은 문서 개수
- 전체 문서 개수 - 출력되지 않은 개수 = 정답

<!-- 접근 방식 및 코드 설명 (코드에 주석으로 자세히 달아놓아도 좋습니다!) -->

#### 제출 이력

![image](https://github.com/user-attachments/assets/25261c1b-b21b-4e14-8fca-0579d688e0c8)
<!-- 캡쳐한 이미지 -->


### 💬 리뷰 요구사항 (선택)
> 중요도가 높은 문서가 있는지 확인하는 과정이 꽤나 번거로워보이는데, 개선할 방법이 있을까요?

<!--  리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 ex) 이 부분을 더 최적화하고 싶은데 좋은 방법이 있을까요? -->
