### PR TITLE
w03_숫자할리갈리 - 이루

### DIFF
--- a/src/main/java/org/example/iroo2001/w03_숫자할리갈리/Main.java
+++ b/src/main/java/org/example/iroo2001/w03_숫자할리갈리/Main.java
@@ -1,0 +1,73 @@
+package org.example.iroo2001.w03_숫자할리갈리;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		int N, M, turn;
+		String winner;
+		ArrayDeque<Integer> doQ, suQ, doGr, suGr;
+
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		doQ = new ArrayDeque<>();
+		suQ = new ArrayDeque<>();
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			doQ.offerFirst(Integer.parseInt(st.nextToken()));
+			suQ.offerFirst(Integer.parseInt(st.nextToken()));
+		}
+
+		turn = 0;
+		doGr = new ArrayDeque<>();
+		suGr = new ArrayDeque<>();
+		while (turn < M) {
+			turn++;
+			if (turn % 2 == 1) {
+				doGr.offer(doQ.poll());
+			} else {
+				suGr.offer(suQ.poll());
+			}
+
+			if (doQ.isEmpty() || suQ.isEmpty()) {
+				break;
+			}
+
+			if (!doGr.isEmpty() && !suGr.isEmpty() && (doGr.peekLast() + suGr.peekLast() == 5)) {
+				while (!doGr.isEmpty()) {
+					suQ.offer(doGr.poll());
+				}
+				while (!suGr.isEmpty()) {
+					suQ.offer(suGr.poll());
+				}
+			} else if (!doGr.isEmpty() && doGr.peekLast() == 5 || !suGr.isEmpty() && suGr.peekLast() == 5) {
+				while (!suGr.isEmpty()) {
+					doQ.offer(suGr.poll());
+				}
+				while (!doGr.isEmpty()) {
+					doQ.offer(doGr.poll());
+				}
+			}
+
+		}
+		
+		if (doQ.size() > suQ.size()) {
+			winner = "do";
+		} else if (doQ.size() < suQ.size()) {
+			winner = "su";
+		} else {
+			winner = "dosu";
+		}
+		System.out.println(winner);
+
+		br.close();
+	}
+}


### PR DESCRIPTION
## #️⃣ 문제링크
[백준 20923 - 숫자 할리갈리 게임](https://www.acmicpc.net/problem/20923)
<!-- url  첨부 -->

## 📝 풀이 내용
평소에 그렇게 자주쓰던 ArrayDeque에 전적으로 의지한 풀이..
문제 조건이 헷갈릴 수 있으니 깐깐하게 해석해야합니다
- 주의할 규칙
i) do와 su가 각각 카드를 1장씩 내려놓았다? -> 각각 한 턴으로 치므로 2턴을 소비함
ii) 입력받는 수를 덱의 어디(앞or뒤)에 놓을 것인가?
iii) 게임 진행 ==도중== 자신의 덱에 있는 카드의 개수가 0개가 되면 상대방의 승리?
-> 여기서 도중은, 진짜 0개가 되자마자(...)를 의미

1. do와 su의 카드를 입력받을 때마다 덱의 가장 앞부분(= 게임에서 덱의 맨 위)에 입력
2. turn 변수를 통해 누가 카드를 내려놓을 차례인지 관리
3. 카드 내려놓은 후(Ground deque에 넣은 후), 덱 크기가 0이 된 사람이 있다면 break
4. do와 su 모두 ground deque가 비어있지 않다면, peekLast로 가장 마지막에 올린 카드의 합이 5인지 검사
-> 합이 5라면, 바닥에 있는 카드 모두를 su의 덱에 넣음
5. do 혹은 su의 바닥 카드 중 가장 마지막에 올린 카드가 5인지 검사
-> 5가 있는 경우, 바닥에 있는 카드 모두를 do의 덱에 넣음
6. turn이 M과 같아지면 break
7. do와 su의 덱 크기 비교하고 우승자 결정
<!-- 접근 방식 및 코드 설명 (코드에 주석으로 자세히 달아놓아도 좋습니다!) -->

#### 제출 이력
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/5b6d3b22-bbcb-496b-b4e5-bff870f361d9" />

<!-- 캡쳐한 이미지 -->


### 💬 리뷰 요구사항 (선택)
덱을 쓰지 않는 풀이도 있을까요?

<!--  리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 ex) 이 부분을 더 최적화하고 싶은데 좋은 방법이 있을까요? -->
