### PR TITLE
w06_케빈베이컨의6단계 - 선민

### DIFF
--- a/src/main/java/org/example/seonmin98/w06_케빈베이컨의6단계/Main.java
+++ b/src/main/java/org/example/seonmin98/w06_케빈베이컨의6단계/Main.java
@@ -1,0 +1,58 @@
+package org.example.seonmin98.w06_케빈베이컨의6단계;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	static int n, m;
+	static int[][] arr;
+	static int minSum, minNum;
+	static final int INF = 1000_000_000;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		
+		arr = new int[n + 1][n + 1];
+		
+		for (int y = 1; y <= n; y++) {
+			Arrays.fill(arr[y], INF);
+			arr[y][y] = 0;
+		}
+		for (int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			arr[a][b] = 1;
+			arr[b][a] = 1;
+		}
+		
+		
+		for (int i = 1; i <= n; i++) {
+			for (int y = 1; y <= n; y++) {
+				for (int x = 1; x <= n; x++) {
+					if (arr[y][i] != INF && arr[i][x] != INF) {
+						arr[y][x] = Math.min(arr[y][x], arr[y][i] + arr[i][x]);						
+					}
+				}
+			}
+		}
+		
+		minSum = Integer.MAX_VALUE;
+		minNum = 0;
+		for (int y = 1; y <= n; y++) {
+			int sum = 0;
+			for (int x = 1; x <= n; x++) {
+				sum += arr[y][x];
+			}
+			if (minSum > sum) {
+				minSum = sum;
+				minNum = y;
+			};
+		}
+		
+		System.out.println(minNum);
+	}
+}


### PR DESCRIPTION
## #️⃣ 문제링크
https://www.acmicpc.net/problem/1389

## 📝 풀이 내용

모든 노드들 간의 최단 경로를 구해야 하는 문제였기에 플로이드-와샬 알고리즘을 써야겠다고 생각했습니다!

따라서, 원래 그래프 문제는 이중 리스트로 풀이하는 걸 좋아하는데 이번에는 이중배열을 사용했습니다!

1. 2차원 배열의 값을 무한대로 초기화 (단, arr[i][i] 는 자기 자신에 해당하므로 0으로 설정)
2. m 개의 입력값을 받아 그래프 관계를 배열에 저장 (바로 갈 수 있으므로 1으로 설정)
3. 1부터 n까지 돌면서 i번을 거쳐서 가는 최소 경로 탐색
4. 각 노드의 케빈 베이컨 수 계산 -> min 값 갱신

#### 제출 이력

![image](https://github.com/user-attachments/assets/e93cf398-411f-4fc6-a058-24c810aa03c1)


### 💬 리뷰 요구사항 (선택)
> 어차피 조건문으로 INF 값을 걸러줄 거라면, INT_MAX 값으로 초기화해도 상관없을까요? 직관적인 걸 좋아하는 저는 그게 더 좋은데, INT_MAX는 아무래도 오버플로우 등의 예외처리가 어렵다보니 적당히 큰 수를 사용하는 게 좋다고 얼핏 들은 것 같아요! 다른 분들은 어떻게 생각하시는지 궁금합니다~

<!--  리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 ex) 이 부분을 더 최적화하고 싶은데 좋은 방법이 있을까요? -->
