### PR TITLE
w08_거짓말 - 선민

### DIFF
--- a/src/main/java/org/example/seonmin98/w08_거짓말/Main.java
+++ b/src/main/java/org/example/seonmin98/w08_거짓말/Main.java
@@ -1,0 +1,64 @@
+package org.example.seonmin98.w08_거짓말;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	static int n, m;
+	static int[] graph;
+	static int[] parties;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken()); // 사람의 수 (1부터 시작)
+		m = Integer.parseInt(st.nextToken()); // 파티의 수
+		
+		graph = new int[n + 1];
+		for (int i = 1; i <= n; i++) {
+			graph[i] = i;
+		} //그래프 초기화
+		
+		st = new StringTokenizer(br.readLine());
+		int trues = Integer.parseInt(st.nextToken());
+		int parent = trues == 0 ? -1 : Integer.parseInt(st.nextToken());
+		for (int i = 1; i < trues; i++) {
+			int child = Integer.parseInt(st.nextToken());
+			graph[child] = parent;
+		} //진실을 아는 사람들 하나의 집합으로 연결
+		
+		parties = new int[m]; //파티의 참석자 대표를 저장할 배열
+		for (int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine());
+			int size = Integer.parseInt(st.nextToken());
+			PriorityQueue<Integer> party = new PriorityQueue<>(); //참석자 대표를 가장 낮은 번호로 설정하기 위한 우선순위 큐
+			for (int p = 0; p < size; p++) {
+				int person = Integer.parseInt(st.nextToken());
+				party.add(person);
+			}
+			int owner = party.poll();
+			while (!party.isEmpty()) {
+				int participant = party.poll();
+				union(findSet(owner), findSet(participant));
+			}
+			parties[i] = owner;
+		}
+		
+		int cnt = 0;
+		if (parent != -1) parent = findSet(parent);
+		for (int i = 0; i < m; i++) {
+			if (findSet(parties[i]) != parent) cnt++;
+		}
+
+		System.out.println(cnt);
+	}
+
+	static void union(int a, int b) {
+		graph[b] = a;
+	}
+
+	static int findSet(int v) {
+		if (graph[v] != v) graph[v] = findSet(graph[v]);
+		return graph[v];
+	}
+}

--- a/src/main/java/org/example/seonmin98/w08_거짓말/Main.java
+++ b/src/main/java/org/example/seonmin98/w08_거짓말/Main.java
@@ -31,17 +31,12 @@ public class Main {
 		for (int i = 0; i < m; i++) {
 			st = new StringTokenizer(br.readLine());
 			int size = Integer.parseInt(st.nextToken());
-			PriorityQueue<Integer> party = new PriorityQueue<>(); //참석자 대표를 가장 낮은 번호로 설정하기 위한 우선순위 큐
-			for (int p = 0; p < size; p++) {
-				int person = Integer.parseInt(st.nextToken());
-				party.add(person);
+			int owner = Integer.parseInt(st.nextToken()); //파티의 대표자
+			for (int p = 1; p < size; p++) {
+				int participant = Integer.parseInt(st.nextToken()); //파티의 참석자
+				union(findSet(owner), findSet(participant)); //파티의 대표자와 참석자 그룹으로 연결
 			}
-			int owner = party.poll();
-			while (!party.isEmpty()) {
-				int participant = party.poll();
-				union(findSet(owner), findSet(participant));
-			}
-			parties[i] = owner;
+			parties[i] = owner; //파티의 대표자 배열에 저장
 		}
 		
 		int cnt = 0;


### PR DESCRIPTION
## #️⃣ 문제링크
https://www.acmicpc.net/problem/1043

## 📝 풀이 내용

#### 첫 번째 접근
- 진실을 알고 있는 사람들을 HashSet 에 저장
- 파티 배열을 입력 받으면서 진실을 알고 있는 사람이 포함되어 있으면 HashSet 에 추가
- 파티 배열 다시 순회하면서 진실을 알고 있는 사람이 포함되어 있는지 확인
=> 테케 다 돌아가서 제출했으나 3%에서 fail... 여러 파티를 거쳐 진실이 전파되는 경우를 고려 X

#### 두 번째 접근
- 유니온 파인드를 써보자!!
- 그래프에 진실을 아는 사람들을 하나의 집합으로 연결
- 파티 배열을 입력 받으면서 같은 파티의 사람들을 그룹으로 연결
- 이 때 파티 배열에는 추후 계산을 위해 대표자 한 명을 넣어두기
- 파티 배열 순회하면서 해당 파티의 대표자가 진실을 아는 사람들 그룹에 속해있는지 확인

#### 제출 이력

![image](https://github.com/user-attachments/assets/2c787dc4-b805-4a4f-b3f3-5b81b90130b4)


### 💬 리뷰 요구사항 (선택)
> 이 문제는 처음 봤을 때 그래프로 풀어야겠다는 생각이 전혀 안들었는데... 첫 번째 접근이 테케도 다 돌아가서 만약 실전 코테였으면 그냥 풀었구나 하고 넘어갔을 것 같아요ㅠㅠ 이렇게 테케가 성의없을 때(?) 직접 테케를 추가해서 풀이를 확인해보는 연습도 필요할까요...??

<!--  리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 ex) 이 부분을 더 최적화하고 싶은데 좋은 방법이 있을까요? -->
