### PR TITLE
w08_거짓말 - 예린

### DIFF
--- a/src/main/java/org/example/rt8632/w08_Lie/boj_1043.java
+++ b/src/main/java/org/example/rt8632/w08_Lie/boj_1043.java
@@ -1,0 +1,80 @@
+package org.example.rt8632.w08_Lie;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class boj_1043 {
+	static int[] p,truth;
+	static List<ArrayList<Integer>> graph;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		//사람 수, 파티의 수
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		//그래프 생성
+		graph = new ArrayList<>();
+		for(int i=0;i<=M;i++) {
+			graph.add(new ArrayList<>());
+		}
+		
+		p = new int[N+1];
+		for(int i=1;i<=N;i++) {
+			p[i] = i;
+		}
+		
+		//진실을 아는 사람의 수와 번호
+		st = new StringTokenizer(br.readLine());
+		int a = Integer.parseInt(st.nextToken());
+		truth = new int[a];
+		for(int i=0;i<a;i++) {
+			truth[i] = Integer.parseInt(st.nextToken());
+		}
+		//파티마다 오는 사람의 수와 번호
+		for(int i=0;i<M;i++) {
+			st = new StringTokenizer(br.readLine());
+			int num = Integer.parseInt(st.nextToken());
+			for(int j=0;j<num;j++) {
+				int input = Integer.parseInt(st.nextToken());
+				graph.get(i).add(input);
+				if(j > 0 || j < num)
+					union(graph.get(i).get(0), input);
+			}
+		}
+		
+		int ans = 0;
+		for(int i=0;i<M;i++) {
+			boolean lie = false;
+			//모임별로 진실을 아는 사람이 있는지 탐색
+			for(int t : graph.get(i)) {
+				for(int j=0;j<a;j++) {
+					//if(t == truth[j])
+						//lie = true;
+					int x = findSet(t);
+					int y = findSet(truth[j]);
+					if(x == y)
+						lie = true;
+				}
+			}
+			
+			if(!lie)
+				ans++;
+		}
+		System.out.println(ans);
+	}
+	public static int findSet(int x) {
+		if (x != p[x])
+			p[x] = findSet(p[x]);
+		return p[x];
+	}
+	
+	public static void union(int x, int y) {
+		int a = findSet(x);
+		int b = findSet(y);
+		p[b] = a;
+	}
+}


### PR DESCRIPTION
## #️⃣ 문제링크
<!-- url  첨부 -->
https://www.acmicpc.net/problem/1043
## 📝 풀이 내용
- 처음에 생각을 잘못해서 진실을 아는 사람이 있는 파티만 안 가면 되는 줄 알았는데 진실을 아는 사람이랑 같은 파티에 있는 사람도 빼줘야 하더라고요...? 이걸로 머리 싸매다가 유니온 파인드 써서 해결했습니다
- 같은 파티에 있는 사람이랑 유니온 파인드해서 findSet값이 같으면 lie가 true가 되도록 만들고, lie가 false인 경우만 카운트하도록 만들었어요
<!-- 접근 방식 및 코드 설명 (코드에 주석으로 자세히 달아놓아도 좋습니다!) -->

#### 제출 이력
- 제 고통의 흔적을 보세요
![image](https://github.com/user-attachments/assets/004611d0-fb00-4f9f-87e8-feddd44d612a)

<!-- 캡쳐한 이미지 -->


### 💬 리뷰 요구사항 (선택)
> 여기에 작성해주세요 :)
- ㅎ ㅏ.... 변수 안헷갈리게 쓰는법좀..........
- 그리고 3중 반복문이라 탐색이 별로 효율적이진 않은 것 같은데 개선할 수 있는 방법이 있을까요?
<!--  리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 ex) 이 부분을 더 최적화하고 싶은데 좋은 방법이 있을까요? -->
