### PR TITLE
w12_테트로미노 - 혜선

### DIFF
--- a/src/main/java/org/example/yhs3237/w12_tetromino/baekjoon14500.java
+++ b/src/main/java/org/example/yhs3237/w12_tetromino/baekjoon14500.java
@@ -1,0 +1,93 @@
+package org.example.yhs3237.w12_tetromino;
+
+import java.io.*;
+import java.util.*;
+
+public class baekjoon14500 {
+    static int N, M;
+    static int[][] paper;
+    static boolean[][] visited;
+    static int max = Integer.MIN_VALUE;
+    // 델타배열 (상우하좌)
+    static int[] dr = {-1, 0, 1, 0};
+    static int[] dc = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken()); // 종이의 세로 크기
+        M = Integer.parseInt(st.nextToken()); // 종이의 가로 크기
+
+        // 초기화 및 입력 받기
+        paper = new int[N][M];
+        visited = new boolean[N][M];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                paper[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // 각 좌표마다 dfs + dfs로 탐색 안 되는 경우 검사
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                visited[i][j] = true;
+                dfs(i, j, 1, paper[i][j]); // 일반적인 모양 탐색
+                visited[i][j] = false; // 방문배열을 dfs실행 시 재사용하기 위한 clear처리
+                checkExtraShape(i, j); // ㅗ, ㅜ, ㅓ, ㅏ 모양 탐색
+            }
+        }
+
+        System.out.println(max);
+    }
+
+    static void dfs(int r, int c, int depth, int sum) {
+        if (depth == 4) {
+            max = Math.max(max, sum);
+            return;
+        }
+
+        for (int d = 0; d < 4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if (onPaper(nr, nc) && !visited[nr][nc]) {
+                visited[nr][nc] = true;
+                dfs(nr, nc, depth + 1, sum + paper[nr][nc]);
+                visited[nr][nc] = false;
+            }
+        }
+    }
+
+    static void checkExtraShape(int r, int c) {
+        // 중심에서 3방향을 뻗는 모양 (ㅗ, ㅜ, ㅓ, ㅏ)
+        for (int i = 0; i < 4; i++) {
+            int sum = paper[r][c];
+            boolean valid = true;
+
+            for (int j = 0; j < 3; j++) {
+                int dir = (i + j) % 4;
+                int nr = r + dr[dir];
+                int nc = c + dc[dir];
+
+                if (!onPaper(nr, nc)) {
+                    valid = false;
+                    break;
+                }
+                sum += paper[nr][nc];
+            }
+
+            if (valid) {
+                max = Math.max(max, sum);
+            }
+        }
+    }
+
+    // 범위 체크
+    static boolean onPaper(int r, int c) {
+        return (r >= 0 && r < N && c >= 0 && c < M);
+    }
+}


### PR DESCRIPTION
## #️⃣ 문제링크
https://www.acmicpc.net/problem/14500
<!-- url  첨부 -->

## 📝 풀이 내용
1. 테트로미노 모양보다 규칙(변이 연결되어 있어야 한다)에 집중해야 한다고 생각해서 모든 좌표에서 시작해서 depth가 4일때 sum을 계산해서 max를 갱신하는 방식으로 dfs를 해야겠다고 생각
-> 예외 발생 (ㅓ, ㅏ, ㅗ, ㅜ 모양은 dfs로 처리하지 못함)
2. 예외 케이스를 처리하기 위한 함수를 dfs를 하고 난 후 실행하면서 다시 한 번 max값 갱신
-> 시간 초과
3. 처음에 visited 배열을 매 좌표마다 초기화해줘야 한다고 생각해서 dfs 실행 전에 매번 생성해주어 오버헤드 발생 & result 배열을 만들어 sum을 구해주는 방식으로 진행했던 부분도 sum을 재귀 호출 시에 전달해주는 방법으로 개선
4. 성공 !
<!-- 접근 방식 및 코드 설명 (코드에 주석으로 자세히 달아놓아도 좋습니다!) -->

#### 제출 이력
![image](https://github.com/user-attachments/assets/83b174f0-4185-4492-bcb4-4de3fded091d)
<!-- 캡쳐한 이미지 -->


### 💬 리뷰 요구사항 (선택)
> dfs 문제에서 재귀호출 할 때, sum 값을 체크하면서 가지치기 하는 방법을 사용하는 경우가 있는데 이걸 사용할지 말지는 어떻게 판단하는 것이 좋을까요?

<!--  리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 ex) 이 부분을 더 최적화하고 싶은데 좋은 방법이 있을까요? -->
