### PR TITLE
w16_문자열 폭발 - 예린

### DIFF
--- a/src/main/java/org/example/rt8632/w16_SentenceExplosion/boj_9935.java
+++ b/src/main/java/org/example/rt8632/w16_SentenceExplosion/boj_9935.java
@@ -1,0 +1,48 @@
+package org.example.rt8632.w16_SentenceExplosion;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class boj_9935 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String s = br.readLine();
+        String target = br.readLine();
+
+        Stack<Character> stack = new Stack<>();
+
+        for(int i=0; i<s.length(); i++) {
+            stack.push(s.charAt(i));
+            if(stack.size() >= target.length()) {
+                boolean flag = true;
+                for(int j=0;j<target.length(); j++) {
+                    if(target.charAt(j) != stack.get(stack.size()-target.length()+j)) {
+                        flag = false;
+                        break;
+                    }
+                }
+                if(flag) {
+                    for(int j=0;j<target.length(); j++)
+                        stack.pop();
+                }
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for(Character ch : stack) {
+            sb.append(ch);
+        }
+
+        if (sb.length() == 0) {
+            System.out.println("FRULA");
+        }
+        else {
+            System.out.println(sb.toString());
+        }
+
+    }
+}
+


### PR DESCRIPTION
## #️⃣ 문제링크
<!-- url  첨부 -->
https://www.acmicpc.net/problem/9935
## 📝 풀이 내용
- 처음에 전체 다 넣고 뒷부분부터 비교했다가 뭔가 이상해서 하나씩 처음부터 넣어보면서 비교하는 식으로 바꿨습니다
<!-- 접근 방식 및 코드 설명 (코드에 주석으로 자세히 달아놓아도 좋습니다!) -->

#### 제출 이력
<img width="1084" alt="스크린샷 2025-06-27 오후 4 28 39" src="https://github.com/user-attachments/assets/cd3028c7-95f2-43c3-9135-0b41c77e60bd" />

<!-- 캡쳐한 이미지 -->


### 💬 리뷰 요구사항 (선택)
> 여기에 작성해주세요 :)
- 문자열 비교는 앞에서부터 봐야할지 뒤에서부터 봐야할지 항상 헷갈리는 거 같아요....
<!--  리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 ex) 이 부분을 더 최적화하고 싶은데 좋은 방법이 있을까요? -->
